### PR TITLE
feat: implement pagination for search results and update table data b…

### DIFF
--- a/app/Http/Controllers/PencarianController.php
+++ b/app/Http/Controllers/PencarianController.php
@@ -24,8 +24,8 @@ class PencarianController extends Controller
         }
 
         $results = $query->orderBy('nama_wajib_ipeda')
-            ->get()
-            ->map(function ($item) {
+            ->paginate(5) // Changed from get() to paginate(5)
+            ->through(function ($item) {
                 return [
                     'id' => $item->id,
                     'nama_wajib_ipeda' => $item->nama_wajib_ipeda,

--- a/resources/js/Pages/Pencarian/Index.vue
+++ b/resources/js/Pages/Pencarian/Index.vue
@@ -1,4 +1,4 @@
-    <script setup>
+<script setup>
     import AppLayout from '@/Layouts/AppLayout.vue';
     import PdfPreview from '@/Components/PdfPreview.vue';
     import { Head, router } from '@inertiajs/vue3';
@@ -7,6 +7,7 @@
     import { FileSearch, Maximize2, Printer } from 'lucide-vue-next';
     import SearchBar from '@/Components/SearchBar.vue';
     import Table from '@/Components/Table.vue';
+    import Pagination from '@/Components/Pagination.vue';
 
     const props = defineProps({
         results: {
@@ -68,6 +69,7 @@
     const printPdf = (item) => {
         window.open(`/print/${item.id}`, '_blank');
     };
+
 </script>
 
     <template>
@@ -97,7 +99,7 @@
                     <!-- Results Table -->
                     <div class="overflow-x-auto">
 
-                        <Table :headers="headers" :rows="results" key-field="id">
+                        <Table :headers="headers" :rows="results?.data ?? []" key-field="id">
                             <template #cell-actions="{ row }">
                                 <div class="flex gap-2">
                                     <button @click.stop="viewPeta(row)"
@@ -113,6 +115,17 @@
                                 </div>
                             </template>
                         </Table>
+
+                        <Pagination :links="results.links ?? []">
+                            <template>
+                                <span v-if="results?.from && results?.to && results?.total">
+                                    Showing {{ results.from }}-{{ results.to }} of {{ results.total }}
+                                </span>
+                                <span v-else>
+                                    Tidak ada data
+                                </span>
+                            </template>
+                        </Pagination>
                     </div>
 
                 </div>
@@ -189,12 +202,12 @@
                                 <div class="flex justify-between items-center">
                                     <span class="text-sm text-gray-500">Tanggal Perubahan</span>
                                     <span class="text-sm font-medium text-gray-900">{{ selectedItem.tgl_perubahan || '-'
-                                    }}</span>
+                                        }}</span>
                                 </div>
                                 <div class="flex justify-between items-center">
                                     <span class="text-sm text-gray-500">Jenis Tanah</span>
                                     <span class="text-sm font-medium text-gray-900">{{ selectedItem.jenis_tanah || '-'
-                                    }}</span>
+                                        }}</span>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
This pull request updates the search results page to support pagination, both on the backend and frontend. The backend now returns paginated results, and the frontend has been updated to display and navigate through paginated data, including a new pagination component and display of result counts.

**Backend pagination support:**

* Changed the `index` method in `PencarianController` to use `paginate(5)` instead of `get()`, returning paginated results to the frontend.

**Frontend pagination integration:**

* Imported the new `Pagination` component in `Index.vue` and rendered it below the table, displaying navigation controls and a summary of shown results. [[1]](diffhunk://#diff-d7b6065197ba7b37bf77bb78c601c1670520a88615172f04bf1b0c47537d872cR10) [[2]](diffhunk://#diff-d7b6065197ba7b37bf77bb78c601c1670520a88615172f04bf1b0c47537d872cR118-R128)
* Updated the `Table` component to use the paginated data (`results.data`) instead of the whole results array, ensuring only the current page's items are shown.…inding